### PR TITLE
[WIP] Add `readOnly` and `mount` flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,13 +186,15 @@ See https://github.com/pojntfx/hydrun for more information.
 
 Usage: hydrun [OPTION...] "<COMMAND...>"
   -a, --arch string         Comma-separated list of architectures to run on (default "amd64")
-  -c, --context string      Directory to use in the container
+  -c, --context string      Directory to use in the container (default is the current working directory)
   -e, --extra-args string   Extra arguments to pass to the Docker command
   -i, --it                  Attach stdin and setup a TTY
   -j, --jobs int            Maximum amount of parallel jobs (default 1)
+  -m, --mount               Enable mounting the directory specified with the context flag (default true)
   -o, --os string           Comma-separated list of operating systems (Docker images) to run on (default "debian")
   -p, --pull                Always pull the specified tags of the operating systems (Docker images)
   -q, --quiet               Disable logging executed commands
+  -r, --readyOnly           Mount the directory specified as read-only
 ```
 
 ## Contributing

--- a/main.go
+++ b/main.go
@@ -142,11 +142,11 @@ Usage: %s [OPTION...] "<COMMAND...>"
 		go func(t Target) {
 			// Construct the arguments
 			dockerArgs := fmt.Sprintf(
-				`run %v%v --platform linux/%v%v %v /bin/sh -c`,
+				`run %v%v--platform linux/%v%v %v /bin/sh -c`,
 				func() string {
 					// Attach stdin and setup a TTY
 					if *itFlag {
-						return "-it"
+						return "-it "
 					}
 
 					return ""
@@ -154,10 +154,10 @@ Usage: %s [OPTION...] "<COMMAND...>"
 				func() string {
 					if *mountFlag {
 						if *readOnlyFlag {
-							return fmt.Sprintf(" -v %v:/data:ro", pwd)
+							return fmt.Sprintf("-v %v:/data:ro ", pwd)
 						}
 
-						return fmt.Sprintf(" -v %v:/data:z", pwd)
+						return fmt.Sprintf("-v %v:/data:z ", pwd)
 					}
 
 					return ""

--- a/main.go
+++ b/main.go
@@ -39,10 +39,12 @@ Usage: %s [OPTION...] "<COMMAND...>"
 	osFlag := pflag.StringP("os", "o", "debian", "Comma-separated list of operating systems (Docker images) to run on")
 	jobFlag := pflag.Int64P("jobs", "j", 1, "Maximum amount of parallel jobs")
 	itFlag := pflag.BoolP("it", "i", false, "Attach stdin and setup a TTY")
-	contextFlag := pflag.StringP("context", "c", "", "Directory to use in the container")
+	contextFlag := pflag.StringP("context", "c", "", "Directory to use in the container (default is the current working directory)")
 	extraArgs := pflag.StringP("extra-args", "e", "", "Extra arguments to pass to the Docker command")
 	pullFlag := pflag.BoolP("pull", "p", false, "Always pull the specified tags of the operating systems (Docker images)")
 	quietFlag := pflag.BoolP("quiet", "q", false, "Disable logging executed commands")
+	mountFlag := pflag.BoolP("mount", "m", true, "Enable mounting the directory specified with the context flag")
+	readOnlyFlag := pflag.BoolP("readyOnly", "r", false, "Mount the directory specified as read-only")
 
 	pflag.Parse()
 
@@ -139,22 +141,42 @@ Usage: %s [OPTION...] "<COMMAND...>"
 
 		go func(t Target) {
 			// Construct the arguments
-			dockerArgs := fmt.Sprintf(`run %v %v:/data:z --platform linux/%v%v %v /bin/sh -c`, func() string {
-				// Attach stdin and setup a TTY
-				if *itFlag {
-					return "-it -v"
-				}
+			dockerArgs := fmt.Sprintf(
+				`run %v%v --platform linux/%v%v %v /bin/sh -c`,
+				func() string {
+					// Attach stdin and setup a TTY
+					if *itFlag {
+						return "-it"
+					}
 
-				return "-v"
-			}(), pwd, t.Architecture, func() string {
-				args := *extraArgs
-				if args != "" {
-					args = " " + args
-				}
+					return ""
+				}(),
+				func() string {
+					if *mountFlag {
+						if *readOnlyFlag {
+							return fmt.Sprintf(" -v %v:/data:ro", pwd)
+						}
 
-				return args
-			}(), getImageNameWithSuffix(t.OS, t.Architecture))
-			commandArgs := fmt.Sprintf(`cd /data && %v`, t.Command)
+						return fmt.Sprintf(" -v %v:/data:z", pwd)
+					}
+
+					return ""
+				}(),
+				t.Architecture,
+				func() string {
+					args := *extraArgs
+					if args != "" {
+						args = " " + args
+					}
+
+					return args
+				}(),
+				getImageNameWithSuffix(t.OS, t.Architecture),
+			)
+			commandArgs := t.Command
+			if *mountFlag {
+				commandArgs = fmt.Sprintf(`cd /data && %v`, t.Command)
+			}
 
 			// Construct the command
 			cmd := exec.Command("docker", append(strings.Split(dockerArgs, " "), commandArgs)...)


### PR DESCRIPTION
This adds two flags which will allow further customization of the mounted directory, which is of particular use for when the used image is not trusted.